### PR TITLE
Add and integrate tolerance module with comprehensive testing

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -22,7 +22,16 @@
            #:point-distance
            #:degrees-to-radians
            #:radians-to-degrees
-           
+
+           ;; Tolerance parameters and functions
+           #:*linear-tolerance*
+           #:*angular-tolerance*
+           #:+two-pi+
+           #:linear-equal
+           #:normalize-angle
+           #:angular-equal
+           #:with-custom-tolerance
+
            ;; Basic Shape classes and functions
            #:shape
            #:shape-id

--- a/src/tolerance.lisp
+++ b/src/tolerance.lisp
@@ -1,0 +1,104 @@
+(in-package :vorm)
+
+;;;; Tolerance and angle normalization utilities for the VORM shape grammar system
+
+;;; Tolerance parameters and constants
+(defparameter *linear-tolerance* 1.0e-6
+  "Tolerance used for linear value comparisons. Two values are considered
+  equal if they differ by less than this amount.")
+
+(defparameter *angular-tolerance* 1.0e-6
+  "Tolerance used for angular value comparisons. Two angles are considered
+  equal if they differ by less than this amount.")
+
+(defconstant +two-pi+ (* 2 pi)
+  "The value of 2π, used for angle normalization and comparison.")
+
+;;; Linear comparison functions
+(defun linear-equal (a b)
+  "Compare two linear values with tolerance.
+   
+   Parameters:
+     A - First value to compare
+     B - Second value to compare
+   
+   Returns:
+     T if the absolute difference is less than *LINEAR-TOLERANCE*, NIL otherwise
+   
+   Example:
+     (linear-equal 1.0 1.0000001) ; => T
+     (linear-equal 1.0 1.01) ; => NIL
+   
+   See also:
+     *LINEAR-TOLERANCE* - The tolerance value used for comparison"
+  (<= (abs (- a b)) *linear-tolerance*))
+
+;;; Angle normalization and comparison
+(defun normalize-angle (angle)
+  "Normalize an angle to the range [0, 2π) using modular arithmetic.
+   
+   Parameters:
+     ANGLE - Any angle value in radians
+   
+   Returns:
+     Equivalent angle normalized to the range [0, 2π)
+   
+   Example:
+     (normalize-angle (* 2.5 pi)) ; => (approximately 0.5π)
+     (normalize-angle (* -0.5 pi)) ; => (approximately 1.5π)
+   
+   See also:
+     +TWO-PI+ - Constant used in calculations
+     ANGULAR-EQUAL - For comparing angles with tolerance"
+  (let ((mod-angle (rem angle +two-pi+)))
+    (if (minusp mod-angle)
+        (+ mod-angle +two-pi+)
+        mod-angle)))
+
+(defun angular-equal (angle1 angle2)
+  "Compare two angular values with tolerance, after normalizing them to [0, 2π).
+   
+   Parameters:
+     ANGLE1 - First angle to compare (in radians)
+     ANGLE2 - Second angle to compare (in radians)
+   
+   Returns:
+     T if the normalized angles differ by less than *ANGULAR-TOLERANCE*
+     or if they differ by approximately 2π, NIL otherwise
+   
+   Example:
+     (angular-equal 0.0 (* 2 pi)) ; => T (equivalent angles)
+     (angular-equal pi (* -1 pi)) ; => T (equivalent angles after normalization)
+   
+   See also:
+     NORMALIZE-ANGLE - Used to normalize angles before comparison
+     *ANGULAR-TOLERANCE* - The tolerance used for comparison"
+  (let* ((norm-angle1 (normalize-angle angle1))
+         (norm-angle2 (normalize-angle angle2))
+         (diff (abs (- norm-angle1 norm-angle2))))
+    ;; Check if the difference is within tolerance or approximately 2π
+    (or (<= diff *angular-tolerance*)
+        (<= (abs (- diff +two-pi+)) *angular-tolerance*))))
+
+;;; Tolerance configuration
+(defmacro with-custom-tolerance ((linear-tol angular-tol) &body body)
+  "Execute body with temporarily adjusted tolerance values.
+   
+   Parameters:
+     LINEAR-TOL - Temporary linear tolerance value to use
+     ANGULAR-TOL - Temporary angular tolerance value to use
+     BODY - Forms to execute with the adjusted tolerance values
+   
+   Returns:
+     The result of the last form in BODY
+   
+   Example:
+     (with-custom-tolerance (1.0e-4 1.0e-4)
+       (linear-equal 0.0001 0.0002))  ; => T with the custom tolerance
+   
+   See also:
+     *LINEAR-TOLERANCE* - Global linear tolerance parameter
+     *ANGULAR-TOLERANCE* - Global angular tolerance parameter"
+  `(let ((*linear-tolerance* ,linear-tol)
+         (*angular-tolerance* ,angular-tol))
+      ,@body))

--- a/tests/main.lisp
+++ b/tests/main.lisp
@@ -21,6 +21,7 @@
     ;; Print a summary of results
     (format t "~&~%=== Test Summary ===")
     (format t "~&Running all vorm test suites...")
+    (format t "~&- Tolerance tests")
     (format t "~&- Shape tests")
     (format t "~&- Grammar tests")
     (format t "~&- Transformation tests")

--- a/tests/tolerance-tests.lisp
+++ b/tests/tolerance-tests.lisp
@@ -1,0 +1,122 @@
+(in-package :vorm.tests)
+
+;;;; Test suite for tolerance and angle normalization utilities
+
+(def-suite tolerance-suite
+  :description "Test suite for the math tolerance"
+  :in vorm-tests)
+
+(in-suite tolerance-suite)
+
+;;; Linear comparison tests
+(test linear-equal-test
+  "Test the linear-equal function"
+  ;; Equal values
+  (is (linear-equal 1.0 1.0))
+  (is (linear-equal 0.0 0.0))
+  (is (linear-equal -5.0 -5.0))
+  
+  ;; Values within tolerance
+  (is (linear-equal 1.0 (+ 1.0 (* 0.5 *linear-tolerance*))))
+  (is (linear-equal 1.0 (- 1.0 (* 0.5 *linear-tolerance*))))
+  
+  ;; Values outside tolerance
+  (is-false (linear-equal 1.0 (+ 1.0 (* 2.0 *linear-tolerance*))))
+  (is-false (linear-equal 1.0 (- 1.0 (* 2.0 *linear-tolerance*)))))
+
+;;; Angular comparison tests
+(test angular-equal-test
+  "Test the angular-equal function"
+  ;; Equal angles
+  (is (angular-equal 0.0 0.0))
+  (is (angular-equal pi pi))
+  (is (angular-equal (* 2 pi) (* 2 pi)))
+  
+  ;; Angles within tolerance
+  (is (angular-equal pi (+ pi (* 0.5 *angular-tolerance*))))
+  (is (angular-equal pi (- pi (* 0.5 *angular-tolerance*))))
+  
+  ;; Equivalent angles across 2π boundaries (now should pass with normalization)
+  (is (angular-equal 0.0 (* 2 pi)))
+  (is (angular-equal (* -1 pi) pi))
+  (is (angular-equal (* -0.1 pi) (* 1.9 pi)))
+  
+  ;; Angles outside tolerance even after normalization
+  (is-false (angular-equal 0.0 (* 2.0 *angular-tolerance*))))
+
+;;; Angle normalization tests
+(test normalize-angle-test
+  "Test the normalize-angle function"
+  ;; Values in range should remain the same
+  (is (= (normalize-angle 0.0) 0.0))
+  (is (= (normalize-angle pi) pi))
+  (is (< (abs (- (normalize-angle (* 1.5 pi)) (* 1.5 pi))) *angular-tolerance*))
+  
+  ;; Values outside range should be normalized
+  (is (< (abs (- (normalize-angle (* 2 pi)) 0.0)) *angular-tolerance*))
+  (is (< (abs (- (normalize-angle (* 3 pi)) pi)) *angular-tolerance*))
+  (is (< (abs (- (normalize-angle (* -1 pi)) pi)) *angular-tolerance*))
+  (is (< (abs (- (normalize-angle (* -0.5 pi)) (* 1.5 pi))) *angular-tolerance*)))
+
+;;; Property-based tests for angle normalization
+(test normalize-angle-properties
+  "Test mathematical properties of angle normalization"
+  
+  ;; Property: Normalization is idempotent (applying it twice is same as once)
+  (let ((test-angles (list 0.0 pi (* 2 pi) (* -1 pi) (* 10 pi) (* -7.5 pi))))
+    (dolist (angle test-angles)
+      (let ((normalized (normalize-angle angle)))
+        (is (angular-equal normalized (normalize-angle normalized))
+            "Normalization should be idempotent: angle ~a" angle))))
+  
+  ;; Property: Normalized angles should be in [0, 2π)
+  (let ((test-angles (list 0.0 pi (* 2 pi) (* -1 pi) (* 10 pi) (* -7.5 pi))))
+    (dolist (angle test-angles)
+      (let ((normalized (normalize-angle angle)))
+        (is (and (>= normalized 0.0) (< normalized +two-pi+))
+            "Normalized angle should be in range [0, 2π): ~a" normalized))))
+  
+  ;; Property: Adding 2π to the input shouldn't change the normalized result
+  (let ((test-angles (list 0.0 pi (* 2 pi) (* -1 pi) (* 10 pi) (* -7.5 pi))))
+    (dolist (angle test-angles)
+      (is (angular-equal (normalize-angle angle) 
+                          (normalize-angle (+ angle +two-pi+)))
+          "Adding 2π shouldn't change normalized result: ~a" angle))))
+
+;;; Edge case tests
+(test angle-edge-cases
+  "Test angle utilities with extreme cases"
+  
+  ;; Very large positive angle
+  (let ((large-angle (* 1000000 +two-pi+)))
+    (is (< (abs (- (normalize-angle large-angle) 0.0)) *angular-tolerance*)
+        "Very large angle should normalize correctly"))
+  
+  ;; Very large negative angle
+  (let ((large-negative-angle (* -1000000 +two-pi+)))
+    (is (< (abs (- (normalize-angle large-negative-angle) 0.0)) *angular-tolerance*)
+        "Very large negative angle should normalize correctly"))
+  
+  ;; Nearly equal angles but outside tolerance
+  (let ((beyond-tolerance (* 2 *angular-tolerance*)))
+    (is-false (angular-equal 0.0 beyond-tolerance)
+              "Angles outside tolerance should not be equal")))
+
+;;; Custom tolerance macro tests
+(test custom-tolerance-test
+  "Test the with-custom-tolerance macro"
+  
+  ;; Test values that are not equal with default tolerance
+  (let ((a 0.0)
+        (b 0.000002))
+    (is-false (linear-equal a b)
+              "Values should not be equal with default tolerance")
+    
+    ;; Test with increased tolerance - fix syntax for macro call
+    (with-custom-tolerance (0.00001 0.00001)
+      (is (linear-equal a b)
+          "Values should be equal with increased tolerance"))
+    
+    ;; Test that tolerance reverts to original value
+    (is-false (linear-equal a b)
+              "Tolerance should be restored after with-custom-tolerance")))

--- a/vorm.asd
+++ b/vorm.asd
@@ -15,6 +15,8 @@
   :components ((:file "package")
                (:file "utils"
                 :depends-on ("package"))
+               (:file "tolerance"
+                :depends-on ("package"))
                (:file "shapes"
                 :depends-on ("package" "utils"))
                (:file "transformations"
@@ -26,7 +28,7 @@
                (:file "interpreter"
                 :depends-on ("package" "utils" "shapes" "transformations" "grammar" "parser"))
                (:file "main" 
-                :depends-on ("package" "utils" "shapes" "transformations" "grammar" "parser" "interpreter")))
+                :depends-on ("package" "utils" "tolerance" "shapes" "transformations" "grammar" "parser" "interpreter")))
   :in-order-to ((asdf:test-op (asdf:test-op "vorm/test"))))
 
 (asdf:defsystem "vorm/test"
@@ -38,6 +40,7 @@
   :pathname "tests"
   :components ((:file "package")
                (:file "main" :depends-on ("package"))
+               (:file "tolerance-tests" :depends-on ("package" "main"))
                (:file "shapes-tests" :depends-on ("package" "main"))
                (:file "transformations-tests" :depends-on ("package" "main"))
                (:file "grammar-tests" :depends-on ("package" "main"))


### PR DESCRIPTION
This commit adds robust tolerance and angle normalization utilities to the VORM system:

- Added tolerance.lisp with improved documentation and code style:
  * Linear and angular tolerance parameters and constants
  * Angle normalization function
  * Linear and angular equality comparison functions
  * Custom tolerance adjustment macro

- Enhanced system integration:
  * Added tolerance.lisp to main system components in vorm.asd
  * Added tolerance-tests.lisp to test system components
  * Properly exported all tolerance symbols in package.lisp

- Implemented comprehensive test suite in tests/tolerance-tests.lisp:
  * Basic tests for linear and angular equality
  * Angle normalization tests
  * Property-based tests for angle operations
  * Edge case tests
  * Custom tolerance macro tests

- Updated test summary to include tolerance tests

All tests pass successfully, adding 47 new assertions to the test suite.